### PR TITLE
Add numpy depedency for Ubuntu 16.04

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ On Ubuntu 16.04:
 
 .. code:: shell
 
-    apt-get install golang libjpeg-turbo8-dev make
+    apt-get install golang libjpeg-turbo8-dev make numpy
 
 On Ubuntu 14.04:
 


### PR DESCRIPTION
Fails without `numpy`:

```
Failed building wheel for go-vncdriver
  Running setup.py clean for go-vncdriver
Failed to build go-vncdriver
Installing collected packages: go-vncdriver, numpy, pyglet, gym, PyYAML, constantly, incremental, zope.interface, twisted, ujson, universe
  Running setup.py install for go-vncdriver ... error
    Complete output from command /home/rock/miniconda2/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-z1rfRl/go-vncdriver/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-PLA3Nx-record/install-record.txt --single-version-externally-managed --compile:
    running install
    running build
    ./build.sh
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
    **ImportError: No module named numpy**
    Could not populate CGO_CFLAGS (see error above)
    Makefile:4: recipe for target 'build' failed
    make: *** [build] Error 1
    Could not build go_vncdriver: Command '['make', 'build']' returned non-zero exit status 2

```