### PR TITLE
Update OS X software requirement for numpy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,7 @@ On OSX:
 
 .. code:: shell
 
+    pip install numpy
     brew install golang libjpeg-turbo
 
 Install Docker


### PR DESCRIPTION
Just did a cold install of Universe and needed to separately install `numpy` to install without errors.

Error:

```
Building wheels for collected packages: go-vncdriver
  Running setup.py bdist_wheel for go-vncdriver ... error
  Complete output from command /usr/local/opt/python3/bin/python3.5 -u -c "import setuptools, tokenize;__file__='/private/var/folders/sr/d5y7vrx11tbczp8nbtfcxmy40000gn/T/pip-build-ks4oqb6g/go-vncdriver/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" bdist_wheel -d /var/folders/sr/d5y7vrx11tbczp8nbtfcxmy40000gn/T/tmpnae92kpfpip-wheel- --python-tag cp35:
  running bdist_wheel
  running build
  ./build.sh
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
  ImportError: No module named 'numpy'
  Could not populate CGO_CFLAGS (see error above)
  make: *** [build] Error 1
  Could not build go_vncdriver: Command '['make', 'build']' returned non-zero exit status 2
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/private/var/folders/sr/d5y7vrx11tbczp8nbtfcxmy40000gn/T/pip-build-ks4oqb6g/go-vncdriver/setup.py", line 79, in <module>
      setup_requires=['numpy'],
    File "/usr/local/Cellar/python3/3.5.2_3/Frameworks/Python.framework/Versions/3.5/lib/python3.5/distutils/core.py", line 148, in setup
      dist.run_commands()
    File "/usr/local/Cellar/python3/3.5.2_3/Frameworks/Python.framework/Versions/3.5/lib/python3.5/distutils/dist.py", line 955, in run_commands
      self.run_command(cmd)
    File "/usr/local/Cellar/python3/3.5.2_3/Frameworks/Python.framework/Versions/3.5/lib/python3.5/distutils/dist.py", line 974, in run_command
      cmd_obj.run()
    File "/usr/local/lib/python3.5/site-packages/wheel/bdist_wheel.py", line 179, in run
      self.run_command('build')
    File "/usr/local/Cellar/python3/3.5.2_3/Frameworks/Python.framework/Versions/3.5/lib/python3.5/distutils/cmd.py", line 313, in run_command
      self.distribution.run_command(command)
    File "/usr/local/Cellar/python3/3.5.2_3/Frameworks/Python.framework/Versions/3.5/lib/python3.5/distutils/dist.py", line 974, in run_command
      cmd_obj.run()
    File "/private/var/folders/sr/d5y7vrx11tbczp8nbtfcxmy40000gn/T/pip-build-ks4oqb6g/go-vncdriver/setup.py", line 25, in run
      self.build()
    File "/private/var/folders/sr/d5y7vrx11tbczp8nbtfcxmy40000gn/T/pip-build-ks4oqb6g/go-vncdriver/setup.py", line 64, in build
      subprocess.check_call(cmd, cwd=here())
    File "/usr/local/Cellar/python3/3.5.2_3/Frameworks/Python.framework/Versions/3.5/lib/python3.5/subprocess.py", line 581, in check_call
      raise CalledProcessError(retcode, cmd)
  subprocess.CalledProcessError: Command '['make', 'build']' returned non-zero exit status 2
```