### PR TITLE
fixing docker version issue, if no API version is defined

### DIFF
--- a/universe/remotes/docker_remote.py
+++ b/universe/remotes/docker_remote.py
@@ -113,6 +113,8 @@ def get_client():
     host = os.environ.get('DOCKER_HOST')
 
     client_api_version = os.environ.get('DOCKER_API_VERSION')
+    if not client_api_version:
+        client_api_version = "auto"
 
     # IP to use for started containers
     if host:


### PR DESCRIPTION
i was having the same error as #7 
this fixed it, i'm not 110% sure of why there was not fallback to auto there might have been a good reason to do so