### PR TITLE
logging shouldn't swallow this error

### DIFF
--- a/universe/rewarder/rewarder_session.py
+++ b/universe/rewarder/rewarder_session.py
@@ -292,15 +292,11 @@ class RewarderSession(object):
         if episode_id is None:
             episode_id = client.factory.env_status.episode_id
         logger.info('[%s] Sending reset for env_id=%s fps=%s episode_id=%s', client.factory.label, client.factory.arg_env_id, client.factory.arg_fps, episode_id)
-        d = client.send_reset(
+        return client.send_reset(
             env_id=client.factory.arg_env_id,
             seed=seed,
             fps=client.factory.arg_fps,
             episode_id=episode_id)
-        def fail(reason):
-            client.factory.record_error(reason)
-        d.addErrback(fail)
-        return d
 
     def pop(self, warn=True, peek_d=None):
         reward_d = {}


### PR DESCRIPTION
> Unless you explicitly raise an error in except block, the Exception is
> caught and stops propagating, and normal execution continues.

- https://twistedmatrix.com/documents/12.0.0/core/howto/defer.html#auto4

`fail` does not raise or return anything, so it swallows the error. Like
not re-raising in an `except` block. This causes normal execution to
resume in callbacks added by callers to this function, which is not what
we want.

Furthermore, we don't need to log anything here at all, since callers
will either log or crash as appropriate. We could log something just in
case a caller fails to handle errors properly, but that would result in
double logging.