### PR TITLE
WIP color map

### DIFF
--- a/universe/vncdriver/server_messages.py
+++ b/universe/vncdriver/server_messages.py
@@ -9,6 +9,7 @@ except ImportError:
 import logging
 import numpy as np
 from universe import pyprofile
+from universe import error
 import struct
 
 logger = logging.getLogger(__name__)
@@ -33,14 +34,21 @@ class PseudoCursorEncoding(object):
     @classmethod
     def parse_rectangle(cls, client, x, y, width, height, data):
         split = width * height * client.framebuffer.bypp
-        image = np.frombuffer(data[:split], np.uint8).reshape((height, width, 4))[:, :, [0, 1, 2]]
+        image = np.frombuffer(data[:split], np.uint8).reshape((height, width, client.framebuffer.bypp))
+
+        if client.framebuffer.bypp == 4:
+            reshaped_image = image[:, :, [0, 1, 2]] # Drop alpha channel
+        elif client.framebuffer.bypp == 1:
+            reshaped_image = np.repeat(image[:,:,np.newaxis], 3, axis=2) # Convert grayscale to rgb
+        else:
+            raise error.Error("framebuffer bytes per pixel of {} is not supported".format(client.framebuffer.bypp))
 
         # Turn raw bytes into uint8 array
         mask = np.frombuffer(data[split:], np.uint8)
         # Turn uint8 array into bit array, and go over the scanlines
         mask = np.unpackbits(mask).reshape((height, -1 if mask.size else 0))[:, :width]
 
-        encoding = cls(image, mask)
+        encoding = cls(reshaped_image, mask)
         return Rectangle(x, y, width, height, encoding)
 
 class RAWEncoding(object):
@@ -49,9 +57,15 @@ class RAWEncoding(object):
 
     @classmethod
     def parse_rectangle(cls, client, x, y, width, height, data):
-        assert client.framebuffer.bpp == 32
-        data = np.frombuffer(data, np.uint8).reshape((height, width, 4))[:, :, [0, 1, 2]]
-        encoding = cls(data)
+        data = np.frombuffer(data, np.uint8).reshape((height, width, client.framebuffer.bypp))
+        if client.framebuffer.bypp == 4:
+            reshaped_data = data[:, :, [0, 1, 2]] # Drop the alpha channel
+        elif client.framebuffer.bypp == 1:
+            reshaped_data = np.repeat(data[:,:], 3, axis=2) # Convert grayscale to rgb
+        else:
+            raise error.Error("framebuffer bytes per pixel of {} is not supported".format(client.framebuffer.bypp))
+
+        encoding = cls(reshaped_data)
         return Rectangle(x, y, width, height, encoding)
 
 class ZlibEncoding(object):

--- a/universe/vncdriver/server_messages.py
+++ b/universe/vncdriver/server_messages.py
@@ -58,15 +58,12 @@ class RAWEncoding(object):
     @classmethod
     def parse_rectangle(cls, client, x, y, width, height, data):
 
-        colourmap =  np.repeat(np.arange(256)[:, np.newaxis], 3, axis=1)
-
         data = np.frombuffer(data, np.uint8).reshape((height, width, client.framebuffer.bypp))
         if client.framebuffer.bypp == 4:
             reshaped_data = data[:, :, [0, 1, 2]] # Drop the alpha channel
         elif client.framebuffer.bypp == 1:
             # http://stackoverflow.com/questions/14448763/is-there-a-convenient-way-to-apply-a-lookup-table-to-a-large-array-in-numpy
-            reshaped_data = colourmap[data[:,:,0]] # Look up all values in the colourmap
-            # import ipdb; ipdb.set_trace()
+            reshaped_data = client.framebuffer.color_map[data[:,:,0]] # Look up all values in the colormap
         else:
             raise error.Error("framebuffer bytes per pixel of {} is not supported".format(client.framebuffer.bypp))
 

--- a/universe/vncdriver/server_messages.py
+++ b/universe/vncdriver/server_messages.py
@@ -57,11 +57,16 @@ class RAWEncoding(object):
 
     @classmethod
     def parse_rectangle(cls, client, x, y, width, height, data):
+
+        colourmap =  np.repeat(np.arange(256)[:, np.newaxis], 3, axis=1)
+
         data = np.frombuffer(data, np.uint8).reshape((height, width, client.framebuffer.bypp))
         if client.framebuffer.bypp == 4:
             reshaped_data = data[:, :, [0, 1, 2]] # Drop the alpha channel
         elif client.framebuffer.bypp == 1:
-            reshaped_data = np.repeat(data[:,:], 3, axis=2) # Convert grayscale to rgb
+            # http://stackoverflow.com/questions/14448763/is-there-a-convenient-way-to-apply-a-lookup-table-to-a-large-array-in-numpy
+            reshaped_data = colourmap[data[:,:,0]] # Look up all values in the colourmap
+            # import ipdb; ipdb.set_trace()
         else:
             raise error.Error("framebuffer bytes per pixel of {} is not supported".format(client.framebuffer.bypp))
 


### PR DESCRIPTION
Start of an implementation of a working [color_map](https://github.com/rfbproto/rfbproto/blob/master/rfbproto.rst#setcolourmapentries)

Current issue can be replicated with the following (from within OpenAI VPN)

```scp -r timshi@0.devbox.sci.openai.org:/tmp/1481832023-19kq0xtdyfpees-0 /tmp/timshi-demo/1481832023-19kq0xtdyfpees-0```

```
 ॐ  bin/vnc_player.py -Co -d /tmp/timshi-demo/1481832023-19kq0xtdyfpees-0/1481832023-19kq0xtdyfpees-0
[2016-12-21 18:16:37,268] No metadata file found at /tmp/timshi-demo/1481832023-19kq0xtdyfpees-0/1481832023-19kq0xtdyfpees-0/metadata.json. Either generate the metadata file with bin/enrich or set metadata_file=None
[2016-12-21 18:16:37,271] Starting playback from /tmp/timshi-demo/1481832023-19kq0xtdyfpees-0/1481832023-19kq0xtdyfpees-0
[2016-12-21 18:16:38,254] XXX Called send_PixelFormat: 1
[2016-12-21 18:16:38,570] XXX Calling recv_SetColorMapEntries
```

The issue here is that we should get a `send_PixelFormat` with `true_color = False` before `recv_SetColorMapEntries` is called. I'm not sure what's going on here.