### PR TITLE
Change RewarderSession.close's reason arg to unicode.

### DIFF
--- a/universe/rewarder/rewarder_session.py
+++ b/universe/rewarder/rewarder_session.py
@@ -34,7 +34,7 @@ class RewarderSession(object):
 
         self.clients = {}
 
-    def close(self, name=None, reason='closed by RewarderSession.close'):
+    def close(self, name=None, reason=u'closed by RewarderSession.close'):
         if name is None:
             names = list(self.names_by_id.values())
         else:


### PR DESCRIPTION
In autobahn, WebsocketProtocol.sendClose checks:
```python
if type(reason) != six.text_type:
                raise Exception("reason must be of type unicode (was '{}')".format(type(reason)))
```
But RewarderSession.close sends this string:
```python
'closed by RewarderSession.close'
```

In Python 3.5.2, that check will pass:
```python
import six
type('closed by RewarderSession.close') == six.text_type # True
type(u'closed by RewarderSession.close') == six.text_type # True
```

In Python 2.7.12, that check will not pass:
```python
import six
type('closed by RewarderSession.close') == six.text_type # False
type(u'closed by RewarderSession.close') == six.text_type # True
```