### PR TITLE
TimeLimit Wrapper

### DIFF
--- a/example/diagnostic-agent/diagnostic-agent.py
+++ b/example/diagnostic-agent/diagnostic-agent.py
@@ -100,7 +100,7 @@ if __name__ == '__main__':
     env = wrappers.Logger(env)
 
     if args.monitor:
-        env = wrappers.Monitor('/tmp/vnc_random_agent', force=True)(env)
+        env = wrappers.Monitor(env, '/tmp/vnc_random_agent', force=True)
 
     env.configure(
         fps=args.fps,

--- a/universe/__init__.py
+++ b/universe/__init__.py
@@ -110,14 +110,13 @@ register(
         'vnc': True,
         'runtime': 'gym-core',
         'metadata_encoding': metadata_pixels,
+        'wrapper_config.TimeLimit.max_episode_steps': 500,
     },
     kwargs={
         'rewarder_observation': True,
         'gym_core_id': 'CartPole-v0',
 },
-    # experience_limit=1000,
     trials=2,
-    timestep_limit=500,
 )
 
 # Dynamics should match CartPole-v0, but have pixel observations
@@ -128,13 +127,12 @@ register(
         'vnc': True,
         'runtime': 'gym-core',
         'metadata_encoding': metadata_pixels,
+        'wrapper_config.TimeLimit.max_episode_steps': 500,
     },
     kwargs={
         'gym_core_id': 'CartPole-v0',
     },
-    # experience_limit=1000,
     trials=2,
-    timestep_limit=500,
 )
 
 # Async cartpole with 4-d observations
@@ -145,14 +143,13 @@ register(
         'vnc': True,
         'runtime': 'gym-core',
         'metadata_encoding': metadata_pixels,
+        'wrapper_config.TimeLimit.max_episode_steps': 500,
     },
     kwargs={
         'rewarder_observation': True,
         'gym_core_id': 'CartPole-v0',
     },
-    # experience_limit=1000,
     trials=2,
-    timestep_limit=500,
 )
 
 register(
@@ -162,13 +159,12 @@ register(
         'vnc': True,
         'runtime': 'gym-core',
         'metadata_encoding': metadata_pixels,
+        'wrapper_config.TimeLimit.max_episode_steps': 500,
     },
     kwargs={
         'gym_core_id': 'CartPole-v0',
     },
-    # experience_limit=1000,
     trials=2,
-    timestep_limit=500,
 )
 
 # gym-core.Atari
@@ -197,13 +193,12 @@ for game in ['air_raid', 'alien', 'amidar', 'assault', 'asterix',
                 'vnc': True,
                 'atari': True,
                 'runtime': 'gym-core',
+                'wrapper_config.TimeLimit.max_episode_steps': 100000,
                 'metadata_encoding': metadata_pixels,
             },
             kwargs={
                 'gym_core_id': gym_core_id,
             },
-            # experience_limit=1000,
-            timestep_limit=100000,
         )
 
         register(
@@ -213,13 +208,12 @@ for game in ['air_raid', 'alien', 'amidar', 'assault', 'asterix',
                 'vnc': True,
                 'atari': True,
                 'runtime': 'gym-core',
+                'wrapper_config.TimeLimit.max_episode_steps': 100000,
                 'metadata_encoding': metadata_pixels,
             },
             kwargs={
                 'gym_core_id': gym_core_id,
             },
-            # experience_limit=1000,
-            timestep_limit=100000,
         )
 
         register(
@@ -229,14 +223,13 @@ for game in ['air_raid', 'alien', 'amidar', 'assault', 'asterix',
                 'vnc': True,
                 'atari': True,
                 'runtime': 'gym-core',
+                'wrapper_config.TimeLimit.max_episode_steps': 100000,
                 'metadata_encoding': metadata_pixels,
             },
             kwargs={
                 'gym_core_id': gym_core_id,
                 'fps': 30,
             },
-            # experience_limit=1000,
-            timestep_limit=100000,
         )
 
         register(
@@ -246,14 +239,13 @@ for game in ['air_raid', 'alien', 'amidar', 'assault', 'asterix',
                 'vnc': True,
                 'atari': True,
                 'runtime': 'gym-core',
+                'wrapper_config.TimeLimit.max_episode_steps': 100000,
                 'metadata_encoding': metadata_pixels,
             },
             kwargs={
                 'gym_core_id': gym_core_id,
                 'fps': 15,
             },
-            # experience_limit=1000,
-            timestep_limit=100000,
         )
 
         deterministic_gym_core_id = '{}Deterministic-v{}'.format(base, version) # e.g. SpaceInvadersDeterministic-v3
@@ -265,12 +257,12 @@ for game in ['air_raid', 'alien', 'amidar', 'assault', 'asterix',
                 'vnc': True,
                 'atari': True,
                 'runtime': 'gym-core',
+                'wrapper_config.TimeLimit.max_episode_steps': 100000,
                 'metadata_encoding': metadata_pixels,
             },
             kwargs={
                 'gym_core_id': deterministic_gym_core_id,
             },
-            timestep_limit=100000,
         )
         register(
             id='gym-core.{}DeterministicSlow-v{}'.format(base, version),
@@ -279,13 +271,13 @@ for game in ['air_raid', 'alien', 'amidar', 'assault', 'asterix',
                 'vnc': True,
                 'atari': True,
                 'runtime': 'gym-core',
+                'wrapper_config.TimeLimit.max_episode_steps': 75000,
                 'metadata_encoding': metadata_pixels,
             },
             kwargs={
                 'gym_core_id': deterministic_gym_core_id,
                 'fps': 15,
             },
-            timestep_limit=75000,
         )
         register(
             id='gym-core.{}DeterministicSync-v{}'.format(base, version),
@@ -294,13 +286,12 @@ for game in ['air_raid', 'alien', 'amidar', 'assault', 'asterix',
                 'vnc': True,
                 'atari': True,
                 'runtime': 'gym-core',
+                'wrapper_config.TimeLimit.max_episode_steps': 75000,
                 'metadata_encoding': metadata_pixels,
             },
             kwargs={
                 'gym_core_id': deterministic_gym_core_id,
             },
-            # experience_limit=1000,
-            timestep_limit=75000,
         )
 
         no_frameskip_gym_core_id = '{}NoFrameskip-v{}'.format(base, version) # e.g. SpaceInvadersNoFrameskip-v3
@@ -311,13 +302,12 @@ for game in ['air_raid', 'alien', 'amidar', 'assault', 'asterix',
                 'vnc': True,
                 'atari': True,
                 'runtime': 'gym-core',
+                'wrapper_config.TimeLimit.max_episode_steps': 400000,
                 'metadata_encoding': metadata_pixels,
             },
             kwargs={
                 'gym_core_id': no_frameskip_gym_core_id,
             },
-            # experience_limit=1000,
-            timestep_limit=400000
         )
 
 #------------------------ Flash game environments ------------------------#
@@ -1378,13 +1368,13 @@ for game in [
             'vnc': True,
             'flashgames': True,
             'runtime': 'flashgames',
+            'wrapper_config.TimeLimit.max_episode_steps': 20000,
             'metadata_encoding': metadata_v1,
             'action_probe': {
                 'type': 'key',
                 'value': 0x60,
             }
         },
-        timestep_limit=20000,
     )
 
 register(
@@ -1394,8 +1384,8 @@ register(
         'vnc': True,
         'flashgames': True,
         'runtime': 'flashgames',
+        'wrapper_config.TimeLimit.max_episode_steps': 10**7,
     },
-    timestep_limit=10**7,
 )
 
 #------------------------ World of Bits and MiniWoB ------------------------#
@@ -1512,9 +1502,9 @@ for game in vnc_world_of_bits:
         tags={
             'vnc': True,
             'wob': True,
-            'runtime': 'world-of-bits'
+            'runtime': 'world-of-bits',
+            'wrapper_config.TimeLimit.max_episode_steps': 10**7,
         },
-        timestep_limit=10**7,
     )
 
 #-------------------------- Complex Games ------------------------#
@@ -1534,8 +1524,8 @@ for id in ['starcraft.TerranAstralBalance-v0']:
             'vnc': True,
             'starcraft': True,
             'runtime': 'starcraft',
+            'wrapper_config.TimeLimit.max_episode_steps': 10**7,
         },
-        timestep_limit=10**7,
     )
 
 for gtav_game in ['gtav.SaneDriving-v0', 'gtav.Speed-v0']:
@@ -1546,8 +1536,8 @@ for gtav_game in ['gtav.SaneDriving-v0', 'gtav.Speed-v0']:
             'vnc': True,
             'gtav': True,
             'runtime': 'vnc-windows',
+            'wrapper_config.TimeLimit.max_episode_steps': 10**7,
         },
-        timestep_limit=10**7,
     )
 
 register(
@@ -1557,8 +1547,8 @@ register(
         'vnc': True,
         'wog': True,
         'runtime': 'vnc-world-of-goo',
+        'wrapper_config.TimeLimit.max_episode_steps': 10**7,
     },
-    timestep_limit=10**7,
 )
 
 for slith_game in ['SlitherIO-v0', 'SlitherIONoSkins-v0', 'SlitherIOEasy-v0']:
@@ -1569,6 +1559,7 @@ for slith_game in ['SlitherIO-v0', 'SlitherIONoSkins-v0', 'SlitherIOEasy-v0']:
             'vnc': True,
             'internet': True,
             'slither': True,
+            'wrapper_config.TimeLimit.max_episode_steps': 10**7,
             'runtime': 'flashgames',
             'metadata_encoding': metadata_v1,
             'action_probe': {
@@ -1576,7 +1567,6 @@ for slith_game in ['SlitherIO-v0', 'SlitherIONoSkins-v0', 'SlitherIOEasy-v0']:
                 'value': 0x60,
             }
         },
-        timestep_limit=10**7,
     )
 
 register(
@@ -1585,10 +1575,10 @@ register(
     tags={
         'vnc': True,
         'metadata_encoding': metadata_v1,
+        'wrapper_config.TimeLimit.max_episode_steps': 10**7,
         'action_probe': {
             'type': 'key',
             'value': 0x60,
-        }
-    },
-    timestep_limit=10**7
+            }
+        },
     )

--- a/universe/vectorized/tests/test_monitoring.py
+++ b/universe/vectorized/tests/test_monitoring.py
@@ -8,7 +8,7 @@ from universe import wrappers
 def test_multiprocessing_env_monitoring():
     with helpers.tempdir() as temp:
         env = wrappers.WrappedMultiprocessingEnv('Pong-v3')
-        env = wrappers.Monitor(temp)(env)
+        env = wrappers.Monitor(env, temp)
         env.configure(n=2)
         env.reset()
         for i in range(2):
@@ -24,7 +24,7 @@ def test_vnc_monitoring():
     with helpers.tempdir() as temp:
         env = gym.make('gym-core.Pong-v3')
         env = wrappers.GymCoreAction(env)
-        env = wrappers.Monitor(temp)(env)
+        env = wrappers.Monitor(env, temp)
 
         env.configure(remotes=2)
         env.reset()

--- a/universe/wrappers/__init__.py
+++ b/universe/wrappers/__init__.py
@@ -16,6 +16,7 @@ from universe.wrappers.vectorize import Vectorize, Unvectorize, WeakUnvectorize
 from universe.wrappers.vision import Vision
 from universe.wrappers.recording import Recording
 from universe.wrappers.monitoring import Monitor
+from universe.wrappers.time_limit import TimeLimit
 
 def wrap(env):
     return Timer(Render(Throttle(env)))

--- a/universe/wrappers/monitoring.py
+++ b/universe/wrappers/monitoring.py
@@ -18,10 +18,8 @@ class _Monitor(core.Wrapper):
         self.uid = uid
         self.mode = mode
 
-    def _configure(self, **kwargs):
-        super(_Monitor, self)._configure(**kwargs)
-
-        # We have to wait until configure to set the monitor because we need the number of instances in a vectorized env
+        # TODO if we want to monitor more than one instance in a vectorized
+        # env we'll have to do this after configure()
         self._start_monitor()
 
     def _start_monitor(self):
@@ -29,7 +27,9 @@ class _Monitor(core.Wrapper):
         from universe import wrappers
         # We need to maintain pointers to these to avoid them being
         # GC'd. They have a weak reference to us to avoid cycles.
-        self._unvectorized_envs = [wrappers.WeakUnvectorize(self, i) for i in range(self.n)]
+        # TODO if we want to monitor more than one instance in a vectorized
+        # env we'll need to actually fix WeakUnvectorize
+        self._unvectorized_envs = [wrappers.WeakUnvectorize(self, i) for i in range(1)]
 
         # For now we only monitor the first env
         self._monitor = monitoring.MonitorManager(self._unvectorized_envs[0])

--- a/universe/wrappers/monitoring.py
+++ b/universe/wrappers/monitoring.py
@@ -2,48 +2,68 @@ import logging
 
 from gym import monitoring
 from universe.vectorized import core  # Cannot import vectorized directly without inducing a cycle
+from universe.wrappers.time_limit import TimeLimit
 
 logger = logging.getLogger(__name__)
 
-def Monitor(directory, video_callable=None, force=False, resume=False,
+class _Monitor(core.Wrapper):
+    def __init__(self, env, directory, video_callable=None, force=False,
+                 resume=False, write_upon_reset=False, uid=None, mode=None):
+        super(_Monitor, self).__init__(env)
+        self.directory = directory
+        self.video_callable = video_callable
+        self.force = force
+        self.resume = resume
+        self.write_upon_reset = write_upon_reset
+        self.uid = uid
+        self.mode = mode
+
+    def _configure(self, **kwargs):
+        super(_Monitor, self)._configure(**kwargs)
+
+        # We have to wait until configure to set the monitor because we need the number of instances in a vectorized env
+        self._start_monitor()
+
+    def _start_monitor(self):
+        # Circular dependencies :(
+        from universe import wrappers
+        # We need to maintain pointers to these to avoid them being
+        # GC'd. They have a weak reference to us to avoid cycles.
+        self._unvectorized_envs = [wrappers.WeakUnvectorize(self, i) for i in range(self.n)]
+
+        # For now we only monitor the first env
+        self._monitor = monitoring.MonitorManager(self._unvectorized_envs[0])
+        self._monitor.start(
+            self.directory,
+            self.video_callable,
+            self.force,
+            self.resume,
+            self.write_upon_reset,
+            self.uid,
+            self.mode,
+        )
+
+    def _step(self, action_n):
+        self._monitor._before_step(action_n[0])
+        observation_n, reward_n, done_n, info = self.env.step(action_n)
+        done_n[0] = self._monitor._after_step(observation_n[0], reward_n[0], done_n[0], info)
+        return observation_n, reward_n, done_n, info
+
+    def _reset(self):
+        self._monitor._before_reset()
+        observation_n = self.env.reset()
+        self._monitor._after_reset(observation_n[0])
+        return observation_n
+
+    def _close(self):
+        super(_Monitor, self)._close()
+        self._monitor.close()
+
+    def set_monitor_mode(self, mode):
+        logger.info("Setting the monitor mode is deprecated and will be removed soon")
+        self._monitor._set_mode(mode)
+
+def Monitor(env, directory, video_callable=None, force=False, resume=False,
             write_upon_reset=False, uid=None, mode=None):
-    class Monitor(core.Wrapper):
-        def _configure(self, **kwargs):
-            super(Monitor, self)._configure(**kwargs)
-
-            # We have to wait until configure to set the monitor because we need the number of instances in a vectorized env
-            self._start_monitor()
-
-        def _start_monitor(self):
-            # Circular dependencies :(
-            from universe import wrappers
-            # We need to maintain pointers to these to avoid them being
-            # GC'd. They have a weak reference to us to avoid cycles.
-            self._unvectorized_envs = [wrappers.WeakUnvectorize(self, i) for i in range(self.n)]
-
-            # For now we only monitor the first env
-            self._monitor = monitoring.MonitorManager(self._unvectorized_envs[0])
-            self._monitor.start(directory, video_callable, force, resume,
-                                write_upon_reset, uid, mode)
-
-        def _step(self, action_n):
-            self._monitor._before_step(action_n[0])
-            observation_n, reward_n, done_n, info = self.env.step(action_n)
-            done_n[0] = self._monitor._after_step(observation_n[0], reward_n[0], done_n[0], info)
-            return observation_n, reward_n, done_n, info
-
-        def _reset(self):
-            self._monitor._before_reset()
-            observation_n = self.env.reset()
-            self._monitor._after_reset(observation_n[0])
-            return observation_n
-
-        def _close(self):
-            super(Monitor, self)._close()
-            self._monitor.close()
-
-        def set_monitor_mode(self, mode):
-            logger.info("Setting the monitor mode is deprecated and will be removed soon")
-            self._monitor._set_mode(mode)
-
-    return Monitor
+    return _Monitor(TimeLimit(env), directory, video_callable, force, resume,
+                    write_upon_reset, uid, mode)

--- a/universe/wrappers/tests/test_time_limit.py
+++ b/universe/wrappers/tests/test_time_limit.py
@@ -9,7 +9,7 @@ register(
     entry_point='universe.envs:DummyVNCEnv',
     tags={
         'vnc': True,
-        'wrapper_config.TimeLimit.max_episode_seconds': 0.01
+        'wrapper_config.TimeLimit._max_episode_seconds': 0.01
         }
     )
 
@@ -18,7 +18,7 @@ register(
     entry_point='universe.envs:DummyVNCEnv',
     tags={
         'vnc': True,
-        'wrapper_config.TimeLimit.max_episode_steps': 1
+        'wrapper_config.TimeLimit._max_episode_steps': 1
         }
     )
 
@@ -29,8 +29,8 @@ def test_steps_limit_restart():
     env.configure(_n=1)
     env.reset()
 
-    assert env.max_episode_seconds == None
-    assert env.max_episode_steps == 1
+    assert env._max_episode_seconds == None
+    assert env._max_episode_steps == 1
 
     # Episode has started
     _, _, done, info = env.step([[]])
@@ -58,8 +58,8 @@ def test_seconds_limit_restart():
     env.configure(_n=1)
     env.reset()
 
-    assert env.max_episode_seconds == 0.01
-    assert env.max_episode_steps == None
+    assert env._max_episode_seconds == 0.01
+    assert env._max_episode_steps == None
 
     # Episode has started
     _, _, done, info = env.step([[]])
@@ -82,5 +82,5 @@ def test_default_time_limit():
     env.configure(_n=1)
     env.reset()
 
-    assert env.max_episode_seconds == wrappers.time_limit.DEFAULT_MAX_EPISODE_SECONDS
-    assert env.max_episode_steps == None
+    assert env._max_episode_seconds == wrappers.time_limit.DEFAULT_MAX_EPISODE_SECONDS
+    assert env._max_episode_steps == None

--- a/universe/wrappers/tests/test_time_limit.py
+++ b/universe/wrappers/tests/test_time_limit.py
@@ -9,7 +9,7 @@ register(
     entry_point='universe.envs:DummyVNCEnv',
     tags={
         'vnc': True,
-        'wrapper_config.TimeLimit.max_episode_seconds': 0.1
+        'wrapper_config.TimeLimit.max_episode_seconds': 0.01
         }
     )
 
@@ -54,7 +54,7 @@ def test_seconds_limit_restart():
     env = wrappers.TimeLimit(env)
     env.configure(_n=1)
 
-    assert env.max_episode_seconds == 0.1
+    assert env.max_episode_seconds == 0.01
     assert env.max_episode_steps == None
 
     # Episode has started
@@ -65,7 +65,7 @@ def test_seconds_limit_restart():
     _, _, done, info = env.step([[]])
     assert done == [False]
 
-    time.sleep(0.2)
+    time.sleep(0.02)
 
     # Limit reached, now we get a done signal and the env resets itself
     _, _, done, info = env.step([[]])
@@ -79,4 +79,3 @@ def test_default_time_limit():
 
     assert env.max_episode_seconds == wrappers.time_limit.DEFAULT_MAX_EPISODE_SECONDS
     assert env.max_episode_steps == None
-

--- a/universe/wrappers/tests/test_time_limit.py
+++ b/universe/wrappers/tests/test_time_limit.py
@@ -9,7 +9,7 @@ register(
     entry_point='universe.envs:DummyVNCEnv',
     tags={
         'vnc': True,
-        'wrapper_config.TimeLimit._max_episode_seconds': 0.01
+        'wrapper_config.TimeLimit.max_episode_seconds': 0.01
         }
     )
 
@@ -18,7 +18,7 @@ register(
     entry_point='universe.envs:DummyVNCEnv',
     tags={
         'vnc': True,
-        'wrapper_config.TimeLimit._max_episode_steps': 1
+        'wrapper_config.TimeLimit.max_episode_steps': 2
         }
     )
 
@@ -30,7 +30,7 @@ def test_steps_limit_restart():
     env.reset()
 
     assert env._max_episode_seconds == None
-    assert env._max_episode_steps == 1
+    assert env._max_episode_steps == 2
 
     # Episode has started
     _, _, done, info = env.step([[]])
@@ -77,7 +77,16 @@ def test_seconds_limit_restart():
 
 
 def test_default_time_limit():
-    env = gym.make('test.DummyVNCEnv-v0')
+    # We need an env without a default limit
+    register(
+        id='test.NoLimitDummyVNCEnv-v0',
+        entry_point='universe.envs:DummyVNCEnv',
+        tags={
+            'vnc': True,
+            },
+    )
+
+    env = gym.make('test.NoLimitDummyVNCEnv-v0')
     env = wrappers.TimeLimit(env)
     env.configure(_n=1)
     env.reset()

--- a/universe/wrappers/tests/test_time_limit.py
+++ b/universe/wrappers/tests/test_time_limit.py
@@ -55,7 +55,7 @@ def test_seconds_limit_restart():
     env.configure(_n=1)
 
     assert env.max_episode_seconds == 0.1
-    assert env.max_episode_seconds == None
+    assert env.max_episode_steps == None
 
     # Episode has started
     _, _, done, info = env.step([[]])

--- a/universe/wrappers/tests/test_time_limit.py
+++ b/universe/wrappers/tests/test_time_limit.py
@@ -1,0 +1,82 @@
+import gym
+import time
+import universe
+from gym.envs import register
+from universe import wrappers
+
+register(
+    id='test.SecondsLimitDummyVNCEnv-v0',
+    entry_point='universe.envs:DummyVNCEnv',
+    tags={
+        'vnc': True,
+        'wrapper_config.TimeLimit.max_episode_seconds': 0.1
+        }
+    )
+
+register(
+    id='test.StepsLimitDummyVNCEnv-v0',
+    entry_point='universe.envs:DummyVNCEnv',
+    tags={
+        'vnc': True,
+        'wrapper_config.TimeLimit.max_episode_steps': 1
+        }
+    )
+
+
+def test_steps_limit_restart():
+    env = gym.make('test.StepsLimitDummyVNCEnv-v0')
+    env = wrappers.TimeLimit(env)
+    env.configure(_n=1)
+
+    assert env.max_episode_seconds == None
+    assert env.max_episode_steps == 1
+
+    # Episode has started
+    _, _, done, info = env.step([[]])
+    assert done == [False]
+
+    # Limit reached, now we get a done signal and the env resets itself
+    _, _, done, info = env.step([[]])
+    assert done == [True]
+
+
+def test_steps_limit_restart_unused_when_not_wrapped():
+    env = gym.make('test.StepsLimitDummyVNCEnv-v0')
+    env.configure(_n=1)
+
+    for i in range(10):
+        _, _, done, info = env.step([[]])
+        assert done == [False]
+
+
+def test_seconds_limit_restart():
+    env = gym.make('test.SecondsLimitDummyVNCEnv-v0')
+    env = wrappers.TimeLimit(env)
+    env.configure(_n=1)
+
+    assert env.max_episode_seconds == 0.1
+    assert env.max_episode_seconds == None
+
+    # Episode has started
+    _, _, done, info = env.step([[]])
+    assert done == [False]
+
+    # Not enough time has passed
+    _, _, done, info = env.step([[]])
+    assert done == [False]
+
+    time.sleep(0.2)
+
+    # Limit reached, now we get a done signal and the env resets itself
+    _, _, done, info = env.step([[]])
+    assert done == [True]
+
+
+def test_default_time_limit():
+    env = gym.make('test.DummyVNCEnv-v0')
+    env = wrappers.TimeLimit(env)
+    env.configure(_n=1)
+
+    assert env.max_episode_seconds == wrappers.time_limit.DEFAULT_MAX_EPISODE_SECONDS
+    assert env.max_episode_steps == None
+

--- a/universe/wrappers/tests/test_time_limit.py
+++ b/universe/wrappers/tests/test_time_limit.py
@@ -27,6 +27,7 @@ def test_steps_limit_restart():
     env = gym.make('test.StepsLimitDummyVNCEnv-v0')
     env = wrappers.TimeLimit(env)
     env.configure(_n=1)
+    env.reset()
 
     assert env.max_episode_seconds == None
     assert env.max_episode_steps == 1
@@ -38,11 +39,13 @@ def test_steps_limit_restart():
     # Limit reached, now we get a done signal and the env resets itself
     _, _, done, info = env.step([[]])
     assert done == [True]
+    assert env._elapsed_steps == 0
 
 
 def test_steps_limit_restart_unused_when_not_wrapped():
     env = gym.make('test.StepsLimitDummyVNCEnv-v0')
     env.configure(_n=1)
+    env.reset()
 
     for i in range(10):
         _, _, done, info = env.step([[]])
@@ -53,6 +56,7 @@ def test_seconds_limit_restart():
     env = gym.make('test.SecondsLimitDummyVNCEnv-v0')
     env = wrappers.TimeLimit(env)
     env.configure(_n=1)
+    env.reset()
 
     assert env.max_episode_seconds == 0.01
     assert env.max_episode_steps == None
@@ -76,6 +80,7 @@ def test_default_time_limit():
     env = gym.make('test.DummyVNCEnv-v0')
     env = wrappers.TimeLimit(env)
     env.configure(_n=1)
+    env.reset()
 
     assert env.max_episode_seconds == wrappers.time_limit.DEFAULT_MAX_EPISODE_SECONDS
     assert env.max_episode_steps == None

--- a/universe/wrappers/time_limit.py
+++ b/universe/wrappers/time_limit.py
@@ -11,11 +11,11 @@ DEFAULT_MAX_EPISODE_SECONDS = 20 * 60.  # Default to 20 minutes if there is no e
 class TimeLimit(vectorized.Wrapper):
     def _configure(self, **kwargs):
         super(TimeLimit, self)._configure(**kwargs)
-        self.max_episode_seconds = self.env.spec.tags.get('wrapper_config.TimeLimit.max_episode_seconds', None)
-        self.max_episode_steps = self.env.spec.tags.get('wrapper_config.TimeLimit.max_episode_steps', None)
+        self._max_episode_seconds = self.env.spec.tags.get('wrapper_config.TimeLimit.max_episode_seconds', None)
+        self._max_episode_steps = self.env.spec.tags.get('wrapper_config.TimeLimit.max_episode_steps', None)
 
-        if self.max_episode_seconds is None and self.max_episode_steps is None:
-            self.max_episode_seconds = DEFAULT_MAX_EPISODE_SECONDS
+        if self._max_episode_seconds is None and self._max_episode_steps is None:
+            self._max_episode_seconds = DEFAULT_MAX_EPISODE_SECONDS
 
         self._elapsed_steps = 0
         self._episode_started_at = None
@@ -26,11 +26,11 @@ class TimeLimit(vectorized.Wrapper):
 
     def _past_limit(self):
         """Return true if we are past our limit"""
-        if self.max_episode_steps is not None and self.max_episode_steps < self._elapsed_steps:
+        if self._max_episode_steps is not None and self._max_episode_steps <= self._elapsed_steps:
             logger.debug("Env has passed the step limit defined by TimeLimit.")
             return True
 
-        if self.max_episode_seconds is not None and self.max_episode_seconds < self._elapsed_seconds:
+        if self._max_episode_seconds is not None and self._max_episode_seconds <= self._elapsed_seconds:
             logger.debug("Env has passed the seconds limit defined by TimeLimit.")
             return True
 

--- a/universe/wrappers/time_limit.py
+++ b/universe/wrappers/time_limit.py
@@ -13,7 +13,7 @@ class TimeLimit(vectorized.Wrapper):
         self.max_episode_seconds = self.env.spec.tags.get('wrapper_config.TimeLimit.max_episode_seconds', None)
         self.max_episode_steps = self.env.spec.tags.get('wrapper_config.TimeLimit.max_episode_steps', None)
 
-        if self.max_episode_steps is None and self.max_episode_steps is None:
+        if self.max_episode_seconds is None and self.max_episode_steps is None:
             self.max_episode_seconds = DEFAULT_MAX_EPISODE_SECONDS
 
     def _step(self, action_n):

--- a/universe/wrappers/time_limit.py
+++ b/universe/wrappers/time_limit.py
@@ -18,9 +18,4 @@ class TimeLimit(vectorized.Wrapper):
 
     def _step(self, action_n):
         observation_n, reward_n, done_n, info = self.env.step(action_n)
-        # We want this to be above Mask, so we know whether or not a
-        # particular index is resetting.
-        if self.diagnostics:
-            with pyprofile.push('vnc_env.diagnostics.add_metadata'):
-                self.diagnostics.add_metadata(observation_n, info['n'])
         return observation_n, reward_n, done_n, info

--- a/universe/wrappers/time_limit.py
+++ b/universe/wrappers/time_limit.py
@@ -27,9 +27,11 @@ class TimeLimit(vectorized.Wrapper):
     def _past_limit(self):
         """Return true if we are past our limit"""
         if self.max_episode_steps is not None and self.max_episode_steps < self._elapsed_steps:
+            logger.debug("Env has passed the step limit defined by TimeLimit.")
             return True
 
         if self.max_episode_seconds is not None and self.max_episode_seconds < self._elapsed_seconds:
+            logger.debug("Env has passed the seconds limit defined by TimeLimit.")
             return True
 
         return False

--- a/universe/wrappers/time_limit.py
+++ b/universe/wrappers/time_limit.py
@@ -35,14 +35,12 @@ class TimeLimit(vectorized.Wrapper):
         return False
 
     def _step(self, action_n):
+        assert self._episode_started_at is not None, "Cannot call env.step() before calling reset()"
         observation_n, reward_n, done_n, info = self.env.step(action_n)
-
         self._elapsed_steps += 1
-        if self._episode_started_at is None:
-            self._episode_started_at = time.time()
 
         if self._past_limit():
-            _ = self.env.reset()  # Force a reset, discard the observation
+            _ = self.reset()  # Force a reset, discard the observation
             done_n = [True] * self.n  # Force a done = True
 
         return observation_n, reward_n, done_n, info

--- a/universe/wrappers/time_limit.py
+++ b/universe/wrappers/time_limit.py
@@ -1,14 +1,15 @@
 import logging
 
 import time
-from universe import pyprofile, vectorized
+from universe import pyprofile
+from universe.vectorized import core
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_MAX_EPISODE_SECONDS = 20 * 60.  # Default to 20 minutes if there is no explicit limit
 
 
-class TimeLimit(vectorized.Wrapper):
+class TimeLimit(core.Wrapper):
     def _configure(self, **kwargs):
         super(TimeLimit, self)._configure(**kwargs)
         self._max_episode_seconds = self.env.spec.tags.get('wrapper_config.TimeLimit.max_episode_seconds', None)

--- a/universe/wrappers/time_limit.py
+++ b/universe/wrappers/time_limit.py
@@ -42,10 +42,10 @@ class TimeLimit(vectorized.Wrapper):
             self._episode_started_at = time.time()
 
         if self._past_limit():
-            observation_n = self.env.reset()  # Force a reset
-            return observation_n, reward_n, [True] * self.n, info  # Return the new observation and done = True
-        else:
-            return observation_n, reward_n, done_n, info
+            _ = self.env.reset()  # Force a reset, discard the observation
+            done_n = [True] * self.n  # Force a done = True
+
+        return observation_n, reward_n, done_n, info
 
     def _reset(self):
         self._episode_started_at = time.time()

--- a/universe/wrappers/time_limit.py
+++ b/universe/wrappers/time_limit.py
@@ -1,5 +1,6 @@
 import logging
 
+import time
 from universe import pyprofile, vectorized
 
 logger = logging.getLogger(__name__)
@@ -16,6 +17,37 @@ class TimeLimit(vectorized.Wrapper):
         if self.max_episode_seconds is None and self.max_episode_steps is None:
             self.max_episode_seconds = DEFAULT_MAX_EPISODE_SECONDS
 
+        self._elapsed_steps = 0
+        self._episode_started_at = None
+
+    @property
+    def _elapsed_seconds(self):
+        return time.time() - self._episode_started_at
+
+    def _past_limit(self):
+        """Return true if we are past our limit"""
+        if self.max_episode_steps is not None and self.max_episode_steps < self._elapsed_steps:
+            return True
+
+        if self.max_episode_seconds is not None and self.max_episode_seconds < self._elapsed_seconds:
+            return True
+
+        return False
+
     def _step(self, action_n):
         observation_n, reward_n, done_n, info = self.env.step(action_n)
-        return observation_n, reward_n, done_n, info
+
+        self._elapsed_steps += 1
+        if self._episode_started_at is None:
+            self._episode_started_at = time.time()
+
+        if self._past_limit():
+            observation_n = self.env.reset()  # Force a reset
+            return observation_n, reward_n, [True] * self.n, info  # Return the new observation and done = True
+        else:
+            return observation_n, reward_n, done_n, info
+
+    def _reset(self):
+        self._episode_started_at = time.time()
+        self._elapsed_steps = 0
+        return self.env.reset()

--- a/universe/wrappers/time_limit.py
+++ b/universe/wrappers/time_limit.py
@@ -1,0 +1,26 @@
+import logging
+
+from universe import pyprofile, vectorized
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_EPISODE_SECONDS = 20 * 60.  # Default to 20 minutes if there is no explicit limit
+
+
+class TimeLimit(vectorized.Wrapper):
+    def _configure(self, **kwargs):
+        super(TimeLimit, self)._configure(**kwargs)
+        self.max_episode_seconds = self.env.spec.tags.get('wrapper_config.TimeLimit.max_episode_seconds', None)
+        self.max_episode_steps = self.env.spec.tags.get('wrapper_config.TimeLimit.max_episode_steps', None)
+
+        if self.max_episode_steps is None and self.max_episode_steps is None:
+            self.max_episode_seconds = DEFAULT_MAX_EPISODE_SECONDS
+
+    def _step(self, action_n):
+        observation_n, reward_n, done_n, info = self.env.step(action_n)
+        # We want this to be above Mask, so we know whether or not a
+        # particular index is resetting.
+        if self.diagnostics:
+            with pyprofile.push('vnc_env.diagnostics.add_metadata'):
+                self.diagnostics.add_metadata(observation_n, info['n'])
+        return observation_n, reward_n, done_n, info


### PR DESCRIPTION
- [x] Add env tag `wrapper_config.TimeLimit.max_episode_seconds`
- [x] Create TimeLimit wrapper that restarts after the timelimit.
- [x] Use whichever comes sooner of `max_episode_seconds` or `max_episode_timesteps`, or 20 minutes
- [x] Remove enforcement from monitor

I have some uncertainty about the desired reset semantics:

After passing the timestep or seconds limit, we currently have the wrapper do a `step`, and then force a `reset`. We then return the normal values from the step, but force a `done = True`. Does this match the semantics we would get from a naturally occurring vexpect gameover match?