### PR TITLE
Build & Doc: simplify install instructions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
+os:
+  - linux
+  - osx
 python:
   - "3.5"
 services:

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,55 @@ build:
 	docker build -t quay.io/openai/universe .
 	docker build -f test.dockerfile -t quay.io/openai/universe:test .
 
+deps:
+	set -e ;\
+	UNAME_S=$$(uname -s) ;\
+	if [ "$$UNAME_S" = "Linux" ]; then \
+		DIST=$$(lsb_release -si) ;\
+	    if [ "$$DIST" = "Ubuntu" ]; then \
+			echo 'Preparing Ubuntu dependencies' ;\
+			VER=$$(lsb_release -sr) ;\
+			if [ "$$VER" = "16.04" ]; then \
+				apt-get install golang libjpeg-turbo8-dev make ;\
+				echo 'Dependencies installed in 16.04' ;\
+			elif [ "$$VER" = "14.04" ]; then \
+				add-apt-repository ppa:ubuntu-lxc/lxd-stable -y ;\
+				apt-get update ;\
+				apt-get install golang libjpeg-turbo8-dev make ;\
+				echo 'Dependencies installed in 14.04' ;\
+			else \
+				echo 'Your Ubuntu version is not supported. Before running the next install step,' ;\
+				echo 'make sure to have golang>=1.5 and libjpeg-turbo8-dev installed.' ;\
+			fi \
+		else \
+			echo 'Your Linux distribution is not supported. Before running the next install step,' ;\
+			echo 'make sure to have golang>=1.5 and libjpeg-turbo8-dev installed.' ;\
+			echo 'In case you have succesfully installed universe, let us know.' ;\
+		fi \
+	elif [ "$$UNAME_S" = "Darwin" ]; then \
+		echo 'Preparing Darwin dependencies' ;\
+		if type xcode-select >&- && xpath=$( xcode-select --print-path ) && [ -d "$xpath" ] && [ -x "$xpath" ]; then \
+			: ;\
+		else \
+			echo 'You might need to first install Command Line Tools by running:' ;\
+			echo 'xcode-select --install' ;\
+		    echo 'then re-run `make deps`' ;\
+		fi ;\
+		if ! type brew >/dev/null 2>&1; then \
+			if ! type port >/dev/null 2>&1; then \
+				echo 'Neither `brew` nor `port` is installed' ;\
+		        echo 'Please visit http://brew.sh/ or https://www.macports.org/' ;\
+		    else \
+				port install go libjpeg-turbo ;\
+		    fi \
+		else \
+			brew install golang libjpeg-turbo ;\
+		fi \
+	else \
+		echo 'Your OS is not supported. Before running the next install step,' ;\
+		echo 'make sure to have golang>=1.5 and libjpeg-turbo8-dev installed.' ;\
+	fi
+
 push:
 	find . -name '*.pyc' -delete
 	docker build -t quay.io/openai/universe .

--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,6 @@ On Ubuntu 16.04:
 
 .. code:: shell
 
-    pip install numpy
     sudo apt-get install golang libjpeg-turbo8-dev make
 
 On Ubuntu 14.04:
@@ -99,11 +98,10 @@ You might need to install Command Line Tools by running:
 
     xcode-select --install
 
-Or ``numpy``, ``libjpeg-turbo`` and ``incremental`` packages:
+and the ``libjpeg-turbo`` package:
 
 .. code:: shell
 
-    pip install numpy incremental
     brew install golang libjpeg-turbo
 
 Install Docker

--- a/README.rst
+++ b/README.rst
@@ -70,32 +70,12 @@ To get started, first install ``universe``:
 
     git clone https://github.com/openai/universe.git
     cd universe
+    sudo make deps  # sudo is omitted if on OSX+HomeBrew
     pip install -e .
 
-If this errors out, you may be missing some required packages. Here's
-the list of required packages we know about so far (please let us know
-if you had to install any others).
-
-On Ubuntu 16.04:
-
-.. code:: shell
-
-    sudo apt-get install golang libjpeg-turbo8-dev make
-
-On Ubuntu 14.04:
-
-.. code:: shell
-
-    sudo add-apt-repository ppa:ubuntu-lxc/lxd-stable  # for newer golang
-    sudo apt-get update
-    sudo apt-get install golang libjpeg-turbo8-dev make
-
-On OSX:
-
-.. code:: shell
-
-    xcode-select --install # if you haven't installed Command Line Tools
-    brew install golang libjpeg-turbo
+If this errors out, you may be missing some required packages. `make deps`
+installs `golang` and `libjpeg-turbo` (please let us know if you had to install
+any others).
 
 Install Docker
 ~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ Installation
 Supported systems
 ~~~~~~~~~~~~~~~~~
 
-We currently support Linux and OSX running Python 2.7 or 3.5.
+We currently support Ubuntu Linux and OSX running Python 2.7 or 3.5.
 
 We recommend setting up a `conda environment <http://conda.pydata.org/docs/using/envs.html>`__
 before getting started, to keep all your Universe-related packages in the same place.
@@ -92,16 +92,9 @@ On Ubuntu 14.04:
 
 On OSX:
 
-You might need to install Command Line Tools by running:
-
 .. code:: shell
 
-    xcode-select --install
-
-and the ``libjpeg-turbo`` package:
-
-.. code:: shell
-
+    xcode-select --install # if you haven't installed Command Line Tools
     brew install golang libjpeg-turbo
 
 Install Docker

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+numpy>=1.10.4
+incremental

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,8 @@ envlist = py27, py35
 skipsdist=True
 
 [testenv]
+whitelist_externals = make
+                      /bin/bash
 passenv=DISPLAY DOCKER_USERNAME DOCKER_PASSWORD FORCE_LATEST_UNIVERSE_DOCKER_RUNTIMES TRAVIS*
 deps =
     pytest
@@ -19,5 +21,6 @@ deps =
     ujson
     boto
 commands =
+    make deps
     pip install -e /usr/local/universe
     pytest {posargs}


### PR DESCRIPTION
This way, explicit support for more systems can be added incrementally.

> * We run Python 3.5 internally, so the Python 3.5 variants will be much more thoroughly performance tested. Please let us know if you see any issues on 2.7.

Note that the tests for python 2.7 can be readily added to the travis.yml.

For OSX, the supported version range should be made explicit (homebrew recommends at least 10.10).