### PR TITLE
Pass along kwargs in reset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ build/
 /.gitfiles
 /.tox
 /.cache
+__pycache__
+*.taghl

--- a/example/reset_with_args.py
+++ b/example/reset_with_args.py
@@ -1,0 +1,12 @@
+from universe import wrappers
+import gym
+import universe
+from universe.utils import ErrorBuffer
+
+env = gym.make('wob.mini.TicTacToe-v0')
+
+env.configure(remotes='vnc://localhost:5900+15900')
+env.reset(query_id='non-parametric bayes models are gross')
+
+while True:
+    observation_n, reward_n, done_n, info = env.step([[]])

--- a/universe/envs/vnc_env.py
+++ b/universe/envs/vnc_env.py
@@ -332,7 +332,7 @@ class VNCEnv(vectorized.Env):
             if hasattr(self, 'remotes_manager') and self._remotes_manager:
                 self._remotes_manager.close()
 
-    def _reset(self, **kwargs):
+    def reset(self, **kwargs):
         self._handle_connect()
 
         if self.rewarder_session:

--- a/universe/envs/vnc_env.py
+++ b/universe/envs/vnc_env.py
@@ -332,7 +332,7 @@ class VNCEnv(vectorized.Env):
             if hasattr(self, 'remotes_manager') and self._remotes_manager:
                 self._remotes_manager.close()
 
-    def _reset(self):
+    def _reset(self, **kwargs):
         self._handle_connect()
 
         if self.rewarder_session:
@@ -341,7 +341,7 @@ class VNCEnv(vectorized.Env):
                 logger.info("Randomly sampled env_id={}".format(env_id))
             else:
                 env_id = None
-            self.rewarder_session.reset(env_id=env_id)
+            self.rewarder_session.reset(seed=None, env_id=env_id, **kwargs)
         else:
             logger.info("No rewarder session exists, so cannot send a reset via the rewarder channel")
         self._reset_mask()

--- a/universe/rewarder/rewarder_client.py
+++ b/universe/rewarder/rewarder_client.py
@@ -28,19 +28,23 @@ class RewarderClient(websocket.WebSocketClientProtocol):
 
         self._connection_result = defer.Deferred()
 
-    def send_reset(self, env_id, seed, fps, episode_id):
+    def send_reset(self, env_id, seed, fps, episode_id, **kwargs):
         self._initial_reset = True
         self._reset = {
             'env_id': env_id,
             'fps': fps,
             'episode_id': episode_id,
         }
+        self._reset.update(kwargs)
 
-        return self.send('v0.env.reset', {
+        header = {
             'seed': seed,
             'env_id': env_id,
             'fps': fps,
-        }, {'episode_id': episode_id}, expect_reply=True)
+        }
+        header.update(kwargs)
+
+        return self.send('v0.env.reset', header, {'episode_id': episode_id}, expect_reply=True)
 
     def _finish_reset(self, episode_id):
         extra_logger.info('[%s] Running finish_reset: %s', self.factory.label, episode_id)

--- a/universe/rewarder/rewarder_session.py
+++ b/universe/rewarder/rewarder_session.py
@@ -228,16 +228,16 @@ class RewarderSession(object):
                 self.errors.clear()
         return errors
 
-    def reset(self, seed=None, env_id=None):
+    def reset(self, seed=None, env_id=None, **kwargs):
         with self.lock:
             for i, reward_buffer in self.reward_buffers.items():
                 reward_buffer.mask()
-        reactor.callFromThread(self._reset, seed=seed, env_id=env_id)
+        reactor.callFromThread(self._reset, seed=seed, env_id=env_id, **kwargs)
 
-    def _reset(self, seed=None, env_id=None):
+    def _reset(self, seed=None, env_id=None, **kwargs):
         with self.lock:
             for client in self.clients.values():
-                d = self._send_env_reset(client, seed=seed, env_id=env_id)
+                d = self._send_env_reset(client, seed=seed, env_id=env_id, **kwargs)
                 # Total hack to capture the variable in the closure
                 def callbacks(client):
                     def success(reply): pass
@@ -247,7 +247,7 @@ class RewarderSession(object):
                 d.addCallback(success)
                 d.addErrback(fail)
 
-    def _send_env_reset(self, client, seed=None, episode_id=None, env_id=None):
+    def _send_env_reset(self, client, seed=None, episode_id=None, env_id=None, **kwargs):
         if episode_id is None:
             episode_id = client.factory.env_status.episode_id
         logger.info('[%s] Sending reset for env_id=%s fps=%s episode_id=%s', client.factory.label, client.factory.arg_env_id, client.factory.arg_fps, episode_id)
@@ -255,7 +255,8 @@ class RewarderSession(object):
             env_id=client.factory.arg_env_id if env_id is None else env_id,
             seed=seed,
             fps=client.factory.arg_fps,
-            episode_id=episode_id)
+            episode_id=episode_id,
+            **kwargs)
 
     def pop(self, warn=True, peek_d=None):
         reward_d = {}

--- a/universe/vectorized/core.py
+++ b/universe/vectorized/core.py
@@ -43,6 +43,9 @@ class Wrapper(Env, gym.Wrapper):
     def configure(self, **kwargs):
         self.env.configure(**kwargs)
 
+    def reset(self, **kwargs):
+        self._reset(**kwargs)
+
 class ObservationWrapper(Wrapper, gym.ObservationWrapper):
     pass
 

--- a/universe/vectorized/core.py
+++ b/universe/vectorized/core.py
@@ -44,7 +44,7 @@ class Wrapper(Env, gym.Wrapper):
         self.env.configure(**kwargs)
 
     def reset(self, **kwargs):
-        self._reset(**kwargs)
+        return self._reset(**kwargs)
 
 class ObservationWrapper(Wrapper, gym.ObservationWrapper):
     pass

--- a/universe/vectorized/vectorize_filter.py
+++ b/universe/vectorized/vectorize_filter.py
@@ -22,10 +22,10 @@ class VectorizeFilter(core.Wrapper):
         self._args = args
         self._kwargs = kwargs
 
-    def _reset(self):
+    def reset(self, **kwargs):
         if self.filter_n is None:
             self.filter_n = [self.filter_factory(*self._args, **self._kwargs) for _ in range(self.n)]
-        observation_n = self.env.reset()
+        observation_n = self.env.reset(**kwargs)
         observation_n = [filter._after_reset(observation) for filter, observation in zip(self.filter_n, observation_n)]
         return observation_n
 

--- a/universe/wrappers/blocking_reset.py
+++ b/universe/wrappers/blocking_reset.py
@@ -2,8 +2,8 @@ from universe import rewarder, spaces, vectorized
 
 class BlockingReset(vectorized.Wrapper):
     """
-By default, a reset in universe is not a blocking operation.  This 
-wrapper changes it. 
+By default, a reset in universe is not a blocking operation.  This
+wrapper changes it.
 """
 
     def __init__(self, *args, **kwargs):
@@ -12,8 +12,8 @@ wrapper changes it.
         self.done_n = None
         self.info = None
 
-    def _reset(self):
-        observation_n = self.env.reset()
+    def _reset(self, **kwargs):
+        observation_n = self.env.reset(**kwargs)
         self.reward_n = [0] * self.n
         self.done_n = [False] * self.n
         self.info = {'n': [{} for _ in range(self.n)]}

--- a/universe/wrappers/blocking_reset.py
+++ b/universe/wrappers/blocking_reset.py
@@ -12,7 +12,7 @@ wrapper changes it.
         self.done_n = None
         self.info = None
 
-    def _reset(self, **kwargs):
+    def reset(self, **kwargs):
         observation_n = self.env.reset(**kwargs)
         self.reward_n = [0] * self.n
         self.done_n = [False] * self.n

--- a/universe/wrappers/experimental/random_env.py
+++ b/universe/wrappers/experimental/random_env.py
@@ -17,8 +17,8 @@ class RandomEnv(vectorized.Wrapper):
     def configure(self, **kwargs):
         super(RandomEnv, self).configure(sample_env_ids=self.env_ids, **kwargs)
 
-    def _reset(self):
-        observation_n = self.env.reset()
+    def _reset(self, **kwargs):
+        observation_n = self.env.reset(**kwargs)
         return [ob['vision'] if ob is not None else ob for ob in observation_n]
 
     def _step(self, action_n):

--- a/universe/wrappers/gym_core.py
+++ b/universe/wrappers/gym_core.py
@@ -104,8 +104,8 @@ class GymCoreObservation(vectorized.Wrapper):
 
         self._gym_core_env = gym.spec(gym_core_id).make()
 
-    def _reset(self):
-        observation_n = self.env.reset()
+    def _reset(self, **kwargs):
+        observation_n = self.env.reset(**kwargs)
         self.reward_n = [0] * self.n
         self.done_n = [False] * self.n
         self.info = {'n': [{} for _ in range(self.n)]}

--- a/universe/wrappers/gym_core.py
+++ b/universe/wrappers/gym_core.py
@@ -104,7 +104,7 @@ class GymCoreObservation(vectorized.Wrapper):
 
         self._gym_core_env = gym.spec(gym_core_id).make()
 
-    def _reset(self, **kwargs):
+    def reset(self, **kwargs):
         observation_n = self.env.reset(**kwargs)
         self.reward_n = [0] * self.n
         self.done_n = [False] * self.n

--- a/universe/wrappers/gym_core_sync.py
+++ b/universe/wrappers/gym_core_sync.py
@@ -22,7 +22,7 @@ class GymCoreSync(vectorized.Wrapper):
         # Metadata has already been cloned
         self.metadata['semantics.async'] = False
 
-    def _reset(self, **kwargs):
+    def reset(self, **kwargs):
         observation_n = self.env.reset(**kwargs)
         new_observation_n, self.reward_n, self.done_n, self.info = self.env.step([[] for i in range(self.n)])
         rewarder.merge_observation_n(observation_n, new_observation_n)

--- a/universe/wrappers/gym_core_sync.py
+++ b/universe/wrappers/gym_core_sync.py
@@ -22,8 +22,8 @@ class GymCoreSync(vectorized.Wrapper):
         # Metadata has already been cloned
         self.metadata['semantics.async'] = False
 
-    def _reset(self):
-        observation_n = self.env.reset()
+    def _reset(self, **kwargs):
+        observation_n = self.env.reset(**kwargs)
         new_observation_n, self.reward_n, self.done_n, self.info = self.env.step([[] for i in range(self.n)])
         rewarder.merge_observation_n(observation_n, new_observation_n)
 

--- a/universe/wrappers/joint.py
+++ b/universe/wrappers/joint.py
@@ -27,12 +27,12 @@ class Joint(vectorized.Wrapper):
     def _render(self, mode='human', close=False):
         return self.env_m[0]._render(mode=mode, close=close)
 
-    def _reset(self):
+    def reset(self, **kwargs):
         # Keep all env[0] action on the main thread, in case we ever
         # need to render. Otherwise we get segfaults from the
         # go-vncdriver.
-        reset_m_async = self.pool.map_async(lambda env: env.reset(), self.env_m[1:])
-        reset = self.env_m[0].reset()
+        reset_m_async = self.pool.map_async(lambda env: env.reset(**kwargs), self.env_m[1:])
+        reset = self.env_m[0].reset(**kwargs)
         reset_m = [reset] + reset_m_async.get()
 
         observation_n = []

--- a/universe/wrappers/monitoring.py
+++ b/universe/wrappers/monitoring.py
@@ -63,9 +63,9 @@ class _UniverseMonitor(core.Wrapper):
         done_n[0] = self._monitor._after_step(observation_n[0], reward_n[0], done_n[0], info)
         return observation_n, reward_n, done_n, info
 
-    def _reset(self):
+    def _reset(self, **kwargs):
         self._monitor._before_reset()
-        observation_n = self.env.reset()
+        observation_n = self.env.reset(**kwargs)
         self._monitor._after_reset(observation_n[0])
         return observation_n
 

--- a/universe/wrappers/monitoring.py
+++ b/universe/wrappers/monitoring.py
@@ -63,7 +63,7 @@ class _UniverseMonitor(core.Wrapper):
         done_n[0] = self._monitor._after_step(observation_n[0], reward_n[0], done_n[0], info)
         return observation_n, reward_n, done_n, info
 
-    def _reset(self, **kwargs):
+    def reset(self, **kwargs):
         self._monitor._before_reset()
         observation_n = self.env.reset(**kwargs)
         self._monitor._after_reset(observation_n[0])

--- a/universe/wrappers/multiprocessing_env.py
+++ b/universe/wrappers/multiprocessing_env.py
@@ -19,7 +19,7 @@ class RemoveNones(vectorized.Wrapper):
         super(RemoveNones, self).__init__(env)
         self.plausible_observation = None
 
-    def _reset(self, **kwargs):
+    def reset(self, **kwargs):
         observation_n = self.env.reset(**kwargs)
         self.plausible_observation = observation_n[0]
         return observation_n
@@ -56,7 +56,7 @@ episodes that are now done.
             else:
                 break
 
-    def _reset(self, **kwargs):
+    def reset(self, **kwargs):
         self._clear_state()
         return self.env.reset(**kwargs)
 

--- a/universe/wrappers/multiprocessing_env.py
+++ b/universe/wrappers/multiprocessing_env.py
@@ -19,8 +19,8 @@ class RemoveNones(vectorized.Wrapper):
         super(RemoveNones, self).__init__(env)
         self.plausible_observation = None
 
-    def _reset(self):
-        observation_n = self.env.reset()
+    def _reset(self, **kwargs):
+        observation_n = self.env.reset(**kwargs)
         self.plausible_observation = observation_n[0]
         return observation_n
 
@@ -56,9 +56,9 @@ episodes that are now done.
             else:
                 break
 
-    def _reset(self):
+    def _reset(self, **kwargs):
         self._clear_state()
-        return self.env.reset()
+        return self.env.reset(**kwargs)
 
     def _step(self, action_n):
         observation_n, reward_n, done_n, info = self.env.step(action_n)

--- a/universe/wrappers/recording.py
+++ b/universe/wrappers/recording.py
@@ -87,23 +87,11 @@ for examining logs.
             self._log_n[i] = RecordingWriter(self._recording_dir, self._instance_id, i, async_write=self._async_write)
         return self._log_n[i]
 
-    def _reset(self):
+    def reset(self, **kwargs):
         if self._episode_ids is None:
             self._episode_ids = [None] * self.n
         if self._step_ids is None:
             self._step_ids = [None] * self.n
-
-        for i in range(self.n):
-            writer = self._get_writer(i)
-            if writer is not None:
-                if self._recording_notes is not None:
-                    writer(type='notes', notes=self._recording_notes)
-                    self._recording_notes = None
-                writer(type='reset', timestamp=time.time())
-            self._episode_ids[i] = self._get_episode_id()
-            self._step_ids[i] = 0
-
-        return self.env.reset()
 
     def _step(self, action_n):
         observation_n, reward_n, done_n, info = self.env.step(action_n)

--- a/universe/wrappers/render.py
+++ b/universe/wrappers/render.py
@@ -24,8 +24,8 @@ class Render(vectorized.Wrapper):
         if 'rgb_array' not in modes:
             modes.append('rgb_array')
 
-    def _reset(self):
-        observation_n = self.env.reset()
+    def _reset(self, **kwargs):
+        observation_n = self.env.reset(**kwargs)
         self._observation = observation_n[0]
         return observation_n
 

--- a/universe/wrappers/render.py
+++ b/universe/wrappers/render.py
@@ -24,7 +24,7 @@ class Render(vectorized.Wrapper):
         if 'rgb_array' not in modes:
             modes.append('rgb_array')
 
-    def _reset(self, **kwargs):
+    def reset(self, **kwargs):
         observation_n = self.env.reset(**kwargs)
         self._observation = observation_n[0]
         return observation_n

--- a/universe/wrappers/throttle.py
+++ b/universe/wrappers/throttle.py
@@ -32,7 +32,7 @@ class Throttle(vectorized.Wrapper):
         self.env.configure(**kwargs)
         self.diagnostics = self.unwrapped.diagnostics
 
-    def _reset(self, **kwargs):
+    def reset(self, **kwargs):
         # We avoid aggregating reward/info across episode boundaries
         # by caching it on the object
         self._deferred_reward_n = None

--- a/universe/wrappers/throttle.py
+++ b/universe/wrappers/throttle.py
@@ -32,14 +32,14 @@ class Throttle(vectorized.Wrapper):
         self.env.configure(**kwargs)
         self.diagnostics = self.unwrapped.diagnostics
 
-    def _reset(self):
+    def _reset(self, **kwargs):
         # We avoid aggregating reward/info across episode boundaries
         # by caching it on the object
         self._deferred_reward_n = None
         self._deferred_done_n = None
         self._deferred_info_n = None
 
-        observation = self.env.reset()
+        observation = self.env.reset(**kwargs)
         self._start_timer()
         return observation
 

--- a/universe/wrappers/time_limit.py
+++ b/universe/wrappers/time_limit.py
@@ -47,7 +47,7 @@ class UniverseTimeLimit(core.Wrapper):
 
         return observation_n, reward_n, done_n, info
 
-    def _reset(self, **kwargs):
+    def reset(self, **kwargs):
         self._episode_started_at = time.time()
         self._elapsed_steps = 0
         return self.env.reset(**kwargs)

--- a/universe/wrappers/time_limit.py
+++ b/universe/wrappers/time_limit.py
@@ -47,8 +47,8 @@ class UniverseTimeLimit(core.Wrapper):
 
         return observation_n, reward_n, done_n, info
 
-    def _reset(self):
+    def _reset(self, **kwargs):
         self._episode_started_at = time.time()
         self._elapsed_steps = 0
-        return self.env.reset()
+        return self.env.reset(**kwargs)
 TimeLimit = UniverseTimeLimit

--- a/universe/wrappers/timer.py
+++ b/universe/wrappers/timer.py
@@ -13,9 +13,9 @@ via pyprofile.
     def configure(self, **kwargs):
         self.env.configure(**kwargs)
 
-    def _reset(self):
+    def _reset(self, **kwargs):
         with pyprofile.push('vnc_env.Timer.reset'):
-            return self.env.reset()
+            return self.env.reset(**kwargs)
 
     def _step(self, action_n):
         start = time.time()

--- a/universe/wrappers/timer.py
+++ b/universe/wrappers/timer.py
@@ -13,7 +13,7 @@ via pyprofile.
     def configure(self, **kwargs):
         self.env.configure(**kwargs)
 
-    def _reset(self, **kwargs):
+    def reset(self, **kwargs):
         with pyprofile.push('vnc_env.Timer.reset'):
             return self.env.reset(**kwargs)
 

--- a/universe/wrappers/vectorize.py
+++ b/universe/wrappers/vectorize.py
@@ -19,7 +19,7 @@ rather than a list of observations), turn it into a vectorized environment with 
         assert self.metadata.get('runtime.vectorized')
         self.n = 1
 
-    def _reset(self, **kwargs):
+    def reset(self, **kwargs):
         observation = self.env.reset(**kwargs)
         return [observation]
 

--- a/universe/wrappers/vectorize.py
+++ b/universe/wrappers/vectorize.py
@@ -19,8 +19,8 @@ rather than a list of observations), turn it into a vectorized environment with 
         assert self.metadata.get('runtime.vectorized')
         self.n = 1
 
-    def _reset(self):
-        observation = self.env.reset()
+    def _reset(self, **kwargs):
+        observation = self.env.reset(**kwargs)
         return [observation]
 
     def _step(self, action):
@@ -37,8 +37,8 @@ Take a vectorized environment with a batch of size 1 and turn it into an unvecto
     autovectorize = False
     metadata = {'runtime.vectorized': False}
 
-    def _reset(self):
-        observation_n = self.env.reset()
+    def reset(self, **kwargs):
+        observation_n = self.env.reset(**kwargs)
         assert(len(observation_n) == 1)
         return observation_n[0]
 

--- a/universe/wrappers/vision.py
+++ b/universe/wrappers/vision.py
@@ -13,7 +13,7 @@ The Vision wrapper extracts the vision modality and discards all others.  This i
 when we only care about the visual input.
 """
 
-    def _reset(self, **kwargs):
+    def reset(self, **kwargs):
         observation_n = self.env.reset(**kwargs)
         return [ob['vision'] if ob is not None else ob for ob in observation_n]
 

--- a/universe/wrappers/vision.py
+++ b/universe/wrappers/vision.py
@@ -5,7 +5,7 @@ logger = logging.getLogger(__name__)
 
 class Vision(vectorized.Wrapper):
     """
-At present, an observation from a vectorized universe environment returns a list of 
+At present, an observation from a vectorized universe environment returns a list of
 dicts. Each dict contains input data for each modality.  Modalities include 'vision'
 and 'text', and it is possible to add other modalities in the future (such as 'audio').
 
@@ -13,8 +13,8 @@ The Vision wrapper extracts the vision modality and discards all others.  This i
 when we only care about the visual input.
 """
 
-    def _reset(self):
-        observation_n = self.env.reset()
+    def _reset(self, **kwargs):
+        observation_n = self.env.reset(**kwargs)
         return [ob['vision'] if ob is not None else ob for ob in observation_n]
 
     def _step(self, action_n):


### PR DESCRIPTION
TL;DR extend reset to be reset(**kwargs) so we can have reset the environment to a given configuration.

See PR: openai/universe#122

Also a related PR at `openai/gym`: https://github.com/openai/gym/pull/533

@joschu