### PR TITLE
Increase healthcheck timeouts

### DIFF
--- a/universe/remotes/docker_remote.py
+++ b/universe/remotes/docker_remote.py
@@ -106,7 +106,7 @@ class DockerManager(object):
         healthcheck.run(
             ['{}:{}'.format(instance.assigner.info['host'], instance.vnc_port) for instance in instances],
             ['{}:{}'.format(instance.assigner.info['host'], instance.rewarder_port) for instance in instances],
-            start_timeout=30,
+            start_timeout=self.start_timeout
         )
 
 def get_client():

--- a/universe/remotes/healthcheck.py
+++ b/universe/remotes/healthcheck.py
@@ -25,7 +25,7 @@ def host_port(address, default_port=None):
 
 class Healthcheck(object):
     def __init__(self, vnc_addresses, rewarder_addresses, timeout=None, start_timeout=None):
-        self.timeout = timeout or (4 * len(vnc_addresses) + 20)
+        self.timeout = timeout or (20 * len(vnc_addresses) + 20)
         self.start_timeout = start_timeout
 
         start_time = time.time()


### PR DESCRIPTION
For world of bits, usually it takes longer to load the environments. The default healthcare timeouts are too small. 

I also propose to make `timeout` a kwarg in `env.configure`. 