### PR TITLE
Fix configure and seeding bugs in MultiprocessingEnv

### DIFF
--- a/universe/vectorized/multiprocessing_env.py
+++ b/universe/vectorized/multiprocessing_env.py
@@ -210,8 +210,8 @@ def reset_n(worker_n):
 def seed_n(worker_n, seed_n):
     accumulated = 0
     for worker in worker_n:
-        action_m = seed_n[accumulated:accumulated+worker.m]
-        worker.seed_start(seed_n)
+        seed_m = seed_n[accumulated:accumulated+worker.m]
+        worker.seed_start(seed_m)
         accumulated += worker.m
 
 
@@ -295,6 +295,8 @@ class MultiprocessingEnv(core.Env):
 
         if episode_limit is not None:
             self._episode_id.episode_limit = episode_limit
+
+        self._configured = True
 
     def _seed(self, seed):
         seed_n(self.worker_n, seed)

--- a/universe/vectorized/tests/test_seeding.py
+++ b/universe/vectorized/tests/test_seeding.py
@@ -7,6 +7,7 @@ from universe.vectorized import MultiprocessingEnv
 
 class SeedEnv(Env):
     def __init__(self):
+        super().__init__()
         self._seed_value = None
 
     def _seed(self, seed=None):
@@ -18,8 +19,8 @@ class SeedEnv(Env):
 
 
 class TestMultiProcessingSeedEnv(unittest.TestCase):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.env_id = None
 
     def setUp(self):
@@ -29,14 +30,11 @@ class TestMultiProcessingSeedEnv(unittest.TestCase):
         entry = env.__class__.__module__ + ':' + env.__class__.__name__
         register(self.env_id, entry_point=entry)
 
-    def test_multiprocessing_env_seed(self):
+    def test_multiprocessing_env_seed_propagates(self):
         venv = MultiprocessingEnv(self.env_id)
-        venv.configure(n=2)
-        venv.seed([1, 2])
-        seed1, seed2 = venv.reset()
-        self.assertEqual(seed1, 1)
-        self.assertEqual(seed2, 2)
-
+        venv.configure(n=4)
+        venv.seed([1, 2, 3, 4])
+        self.assertEqual(venv.reset(), [1, 2, 3, 4])
 
 if __name__ == '__main__':
     unittest.main()

--- a/universe/vectorized/tests/test_seeding.py
+++ b/universe/vectorized/tests/test_seeding.py
@@ -1,4 +1,6 @@
-import unittest
+import sys
+
+import pytest
 
 from gym import Env
 from gym.envs import register
@@ -17,24 +19,18 @@ class SeedEnv(Env):
     def _reset(self):
         return self._seed_value
 
+def setup_module(_):
+    env = SeedEnv()
+    env_id = env.__class__.__name__ + '-v0'
+    entry = env.__class__.__module__ + ':' + env.__class__.__name__
+    register(env_id, entry_point=entry)
 
-class TestMultiProcessingSeedEnv(unittest.TestCase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.env_id = None
 
-    def setUp(self):
-        super().setUp()
-        env = SeedEnv()
-        self.env_id = env.__class__.__name__ + '-v0'
-        entry = env.__class__.__module__ + ':' + env.__class__.__name__
-        register(self.env_id, entry_point=entry)
-
-    def test_multiprocessing_env_seed_propagates(self):
-        venv = MultiprocessingEnv(self.env_id)
-        venv.configure(n=4)
-        venv.seed([1, 2, 3, 4])
-        self.assertEqual(venv.reset(), [1, 2, 3, 4])
+def test_multiprocessing_env_seed_propagates():
+    venv = MultiprocessingEnv('SeedEnv-v0')
+    venv.configure(n=4)
+    venv.seed([1, 2, 3, 4])
+    assert venv.reset() == [1, 2, 3, 4]
 
 if __name__ == '__main__':
-    unittest.main()
+    pytest.main(sys.argv)

--- a/universe/vectorized/tests/test_seeding.py
+++ b/universe/vectorized/tests/test_seeding.py
@@ -1,0 +1,42 @@
+import unittest
+
+from gym import Env
+from gym.envs import register
+from universe.vectorized import MultiprocessingEnv
+
+
+class SeedEnv(Env):
+    def __init__(self):
+        self._seed_value = None
+
+    def _seed(self, seed=None):
+        self._seed_value = seed
+        return [seed]
+
+    def _reset(self):
+        return self._seed_value
+
+
+class TestMultiProcessingSeedEnv(unittest.TestCase):
+    def __init__(self):
+        super().__init__()
+        self.env_id = None
+
+    def setUp(self):
+        super().setUp()
+        env = SeedEnv()
+        self.env_id = env.__class__.__name__ + '-v0'
+        entry = env.__class__.__module__ + ':' + env.__class__.__name__
+        register(self.env_id, entry_point=entry)
+
+    def test_multiprocessing_env_seed(self):
+        venv = MultiprocessingEnv(self.env_id)
+        venv.configure(n=2)
+        venv.seed([1, 2])
+        seed1, seed2 = venv.reset()
+        self.assertEqual(seed1, 1)
+        self.assertEqual(seed2, 2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/universe/vectorized/tests/test_seeding.py
+++ b/universe/vectorized/tests/test_seeding.py
@@ -9,7 +9,7 @@ from universe.vectorized import MultiprocessingEnv
 
 class SeedEnv(Env):
     def __init__(self):
-        super().__init__()
+        super(SeedEnv, self).__init__()
         self._seed_value = None
 
     def _seed(self, seed=None):


### PR DESCRIPTION
As is, `universe.vectorized.MultiprocessingEnv` has two bugs:

* In `gym` versions at or before `0.7.4`, a `core.Env` has a flag `self._configured`, usually set by `configure()`, but not set by the `configure()` method overridden by `MultiprocessingEnv`. This causes `configure()` to be re-called with empty arguments upon `reset`.
* `seed_n` does not seed individual workers, it instead re-uses the same first seed among all worker environments.

This PR adds a single test which checks for both issues and fixes the bugs.